### PR TITLE
Release v0.1.0-RC9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ ThisBuild / dynverSonatypeSnapshots := true
 ThisBuild / scalaVersion            := scala212
 ThisBuild / crossScalaVersions      := Seq(scala212, scala213, scala3)
 ThisBuild / versionScheme           := Some("semver-spec")
-ThisBuild / version                 := "0.1.0-RC8"
+ThisBuild / version                 := "0.1.0-RC9"
 
 // Scalafix configuration
 ThisBuild / semanticdbEnabled := true

--- a/core-aspose/src/main/scala/Main.scala
+++ b/core-aspose/src/main/scala/Main.scala
@@ -15,7 +15,7 @@ import utils.aspose.AsposeLicense.Product
 object Main extends AbstractMain[AsposeConfig] {
 
   override protected def programName: String       = "xlcr-aspose"
-  override protected def programVersion: String    = "1.1"
+  override protected def programVersion: String    = "0.1.0-RC9"
   override protected def emptyConfig: AsposeConfig = AsposeConfig()
 
   // Getter methods to extract fields from AsposeConfig

--- a/core/src/main/scala/Main.scala
+++ b/core/src/main/scala/Main.scala
@@ -12,7 +12,7 @@ import cli.CommonCLI.BaseConfig
 object Main extends AbstractMain[BaseConfig] {
 
   override protected def programName: String     = "xlcr"
-  override protected def programVersion: String  = "1.0"
+  override protected def programVersion: String  = "0.1.0-RC9"
   override protected def emptyConfig: BaseConfig = BaseConfig()
 
   // Getter methods to extract fields from BaseConfig


### PR DESCRIPTION
## Summary
- Bump version to 0.1.0-RC9 across all modules
- Synchronize version references in Main classes
- Prepare for release candidate 9

## Changes
- Update version in `build.sbt` from 0.1.0-RC8 to 0.1.0-RC9
- Update `core/src/main/scala/Main.scala` programVersion from 1.0 to 0.1.0-RC9
- Update `core-aspose/src/main/scala/Main.scala` programVersion from 1.1 to 0.1.0-RC9

## Test Plan
- [ ] Build all modules successfully
- [ ] Verify version output with `--version` flag
- [ ] Run tests to ensure no regressions
- [ ] Tag release after merge

🤖 Generated with [Claude Code](https://claude.ai/code)