### PR TITLE
fix: disable test doc generation for Scala 3 in coreAspose

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -213,6 +213,10 @@ lazy val coreAspose = (project in file("core-aspose"))
       if (scalaVersion.value.startsWith("3.")) Seq.empty // ⇒ empty jar
       else (Compile / doc / sources).value
     },
+    Test / doc / sources := {
+      if (scalaVersion.value.startsWith("3.")) Seq.empty // ⇒ empty jar for tests too
+      else (Test / doc / sources).value
+    },
 
     // --- ② Make sure the (empty) jar is still attached & published ---
     Compile / packageDoc / publishArtifact := true,


### PR DESCRIPTION
- Add Test/doc/sources configuration to return empty sources for Scala 3
- Fixes deployment error: "package com.aspose.slides contains object and package with same name: ms"
- Scala 3's Dotty compiler doesn't allow packages and objects with the same name
- This is a known issue with Aspose libraries and Scala 3

🤖 Generated with [Claude Code](https://claude.ai/code)