### PR TITLE
refactor: split --remove-watermarks-aggressive into --remove-watermarks --aggressive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,9 @@ xlcr convert -i presentation.pptx -o output.html --strip-masters
 # Remove watermarks from PDF
 xlcr convert -i watermarked.pdf -o clean.pdf --remove-watermarks
 
+# Aggressive mode: also strip ALL trailing vector art (may remove legitimate artwork)
+xlcr convert -i stubborn.pdf -o clean.pdf --remove-watermarks --aggressive
+
 # Two-stage PDF -> editable PowerPoint (recommended)
 xlcr convert -i document.pdf -o intermediate.html
 xlcr convert -i intermediate.html -o presentation.pptx
@@ -163,6 +166,7 @@ Logging uses `zio-logging` with SLF4J2 bridge — all logs (ZIO, Tika, POI, Aspo
 | `backend` | `/convert`, `/split` | Force specific backend: `aspose`, `libreoffice`, or `xlcr` (no fallback) |
 | `detect=tika` | `/convert`, `/split` | Force Tika content detection, ignore Content-Type header |
 | `remove-watermarks` | `/convert` | Remove watermark artifacts from PDF (PDF-to-PDF only) |
+| `aggressive` | `/convert` | With `remove-watermarks`: strip all trailing vector art after page text (may remove legitimate art) |
 | `password` | `/convert`, `/split` | Password for encrypted documents |
 | `strip-masters` | `/convert` | Strip master/layout slides from PowerPoint |
 | `fixed-layout` | `/convert` | Use fixed layout for PDF to HTML |

--- a/core-aspose/src/main/scala/com/tjclp/xlcr/aspose/conversions.scala
+++ b/core-aspose/src/main/scala/com/tjclp/xlcr/aspose/conversions.scala
@@ -700,7 +700,7 @@ private[aspose] def processPdf(
         $(document) { doc =>
           val pgs   = doc.getPages
           val total = pgs.size()
-          if options.removeWatermarksAggressive then
+          if options.aggressive then
             var pi = 0
             while pi < total do
               stripTrailingPathOps(pgs.get_Item(pi + 1))

--- a/core-aspose/test/src/com/tjclp/xlcr/aspose/PdfWatermarkRemovalSpec.scala
+++ b/core-aspose/test/src/com/tjclp/xlcr/aspose/PdfWatermarkRemovalSpec.scala
@@ -227,6 +227,22 @@ class PdfWatermarkRemovalSpec extends AnyWordSpec with Matchers:
     }
   }
 
+  "processPdf with aggressive=true" should {
+    "strip trailing vector artwork that normal mode preserves" in {
+      val pdfWithTrailingVector = createPdfWithTrailingVectorLine()
+      hasTrailingVectorCommandsAfterLastText(pdfWithTrailingVector) shouldBe true
+
+      val input = Content.fromChunk[Mime.Pdf](
+        Chunk.fromArray(pdfWithTrailingVector),
+        Mime.pdf
+      )
+      val options = ConvertOptions(removeWatermarks = true, aggressive = true)
+      val result  = run(processPdf(input, options))
+
+      hasTrailingVectorCommandsAfterLastText(result.data.toArray) shouldBe false
+    }
+  }
+
   "AsposeTransforms.convert PDF->PDF" should {
     "reject bare PDF->PDF with no processing flags" in {
       val watermarked = createWatermarkedPdf()

--- a/core/src/main/scala/com/tjclp/xlcr/cli/Commands.scala
+++ b/core/src/main/scala/com/tjclp/xlcr/cli/Commands.scala
@@ -218,12 +218,12 @@ object Commands:
   private val removeWatermarksFlag: Opts[Boolean] =
     Opts.flag("remove-watermarks", help = "Remove watermark artifacts from PDF").orFalse
 
-  private val removeWatermarksAggressiveFlag: Opts[Boolean] =
+  private val aggressiveFlag: Opts[Boolean] =
     Opts
       .flag(
-        "remove-watermarks-aggressive",
+        "aggressive",
         help =
-          "Aggressively remove all trailing vector watermarks from PDF (may strip legitimate art)"
+          "Use aggressive heuristics with --remove-watermarks (strips all trailing vector art; may remove legitimate artwork)"
       )
       .orFalse
 
@@ -240,7 +240,7 @@ object Commands:
       fixedLayoutFlag,
       noEmbedResourcesFlag,
       removeWatermarksFlag,
-      removeWatermarksAggressiveFlag
+      aggressiveFlag
     ).mapN {
       (
         password,
@@ -254,7 +254,7 @@ object Commands:
         fixedLayout,
         noEmbed,
         removeWm,
-        removeWmAggressive
+        aggressive
       ) =>
         ConvertOptions(
           password = password,
@@ -267,9 +267,11 @@ object Commands:
           stripMasters = stripM,
           flowingLayout = !fixedLayout,
           embedResources = !noEmbed,
-          removeWatermarks = removeWm || removeWmAggressive,
-          removeWatermarksAggressive = removeWmAggressive
+          removeWatermarks = removeWm,
+          aggressive = aggressive
         )
+    }.validate("--aggressive requires --remove-watermarks") { o =>
+      o.removeWatermarks || !o.aggressive
     }
 
   // ============================================================================

--- a/core/src/main/scala/com/tjclp/xlcr/types/ConvertOptions.scala
+++ b/core/src/main/scala/com/tjclp/xlcr/types/ConvertOptions.scala
@@ -28,7 +28,8 @@ final case class ConvertOptions(
 
   // --- PDF processing options (Aspose.PDF) ---
   removeWatermarks: Boolean = false,
-  removeWatermarksAggressive: Boolean = false
+  // modifier for removeWatermarks: strip ALL trailing vector art, not just detected watermarks
+  aggressive: Boolean = false
 ):
 
   /** True when every field matches the default `ConvertOptions()`. */
@@ -48,7 +49,7 @@ final case class ConvertOptions(
     if !flowingLayout then parts += "fixed-layout"
     if !embedResources then parts += "no-embed-resources"
     if removeWatermarks then parts += "remove-watermarks"
-    if removeWatermarksAggressive then parts += "remove-watermarks-aggressive"
+    if aggressive then parts += "aggressive"
     parts.result().mkString(", ")
   end nonDefaultSummary
 end ConvertOptions

--- a/core/test/src/cli/CommandsSpec.scala
+++ b/core/test/src/cli/CommandsSpec.scala
@@ -60,6 +60,36 @@ class CommandsSpec extends AnyFlatSpec with Matchers:
       case _ => fail("Expected Convert command")
   }
 
+  it should "parse watermark removal flags" in {
+    val result = parse(
+      Seq("convert", "-i", "in.pdf", "-o", "out.pdf", "--remove-watermarks", "--aggressive")
+    )
+
+    result.isRight shouldBe true
+    result.toOption.get match
+      case CliCommand.Convert(args) =>
+        args.options.removeWatermarks shouldBe true
+        args.options.aggressive shouldBe true
+      case _ => fail("Expected Convert command")
+  }
+
+  it should "parse --remove-watermarks without --aggressive" in {
+    val result = parse(Seq("convert", "-i", "in.pdf", "-o", "out.pdf", "--remove-watermarks"))
+
+    result.isRight shouldBe true
+    result.toOption.get match
+      case CliCommand.Convert(args) =>
+        args.options.removeWatermarks shouldBe true
+        args.options.aggressive shouldBe false
+      case _ => fail("Expected Convert command")
+  }
+
+  it should "reject --aggressive without --remove-watermarks" in {
+    val result = parse(Seq("convert", "-i", "in.pdf", "-o", "out.pdf", "--aggressive"))
+
+    result.isLeft shouldBe true
+  }
+
   it should "parse convert command with backend option" in {
     val result = parse(Seq("convert", "-i", "in.pdf", "-o", "out.pptx", "-b", "aspose"))
 

--- a/xlcr/src/main/scala/com/tjclp/xlcr/server/http/RequestHandler.scala
+++ b/xlcr/src/main/scala/com/tjclp/xlcr/server/http/RequestHandler.scala
@@ -142,9 +142,8 @@ object RequestHandler:
       stripMasters = boolParam("strip-masters"),
       flowingLayout = !boolParam("fixed-layout"),
       embedResources = !boolParam("no-embed-resources"),
-      removeWatermarks =
-        boolParam("remove-watermarks") || boolParam("remove-watermarks-aggressive"),
-      removeWatermarksAggressive = boolParam("remove-watermarks-aggressive")
+      removeWatermarks = boolParam("remove-watermarks"),
+      aggressive = boolParam("aggressive")
     )
   end parseConvertOptions
 

--- a/xlcr/test/src/server/RequestHandlerSpec.scala
+++ b/xlcr/test/src/server/RequestHandlerSpec.scala
@@ -29,4 +29,20 @@ class RequestHandlerSpec extends AnyWordSpec with Matchers:
 
       options.sheetNames shouldBe List("Q1", "Q2", "Q3")
     }
+
+    "parse watermark removal params" in {
+      val options = RequestHandler.parseConvertOptions(
+        request("/convert?remove-watermarks=true&aggressive=true")
+      )
+
+      options.removeWatermarks shouldBe true
+      options.aggressive shouldBe true
+    }
+
+    "default watermark removal params to false" in {
+      val options = RequestHandler.parseConvertOptions(request("/convert"))
+
+      options.removeWatermarks shouldBe false
+      options.aggressive shouldBe false
+    }
   }

--- a/xlcr/test/src/server/RequestHandlerSpec.scala
+++ b/xlcr/test/src/server/RequestHandlerSpec.scala
@@ -1,0 +1,32 @@
+package com.tjclp.xlcr.server.http
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import zio.http.{Method, Request, URL}
+
+class RequestHandlerSpec extends AnyWordSpec with Matchers:
+
+  private def request(path: String): Request =
+    Request(
+      method = Method.GET,
+      url = URL.decode(path).getOrElse(URL.empty)
+    )
+
+  "RequestHandler.parseConvertOptions" should {
+    "collect repeated sheet query parameters" in {
+      val options = RequestHandler.parseConvertOptions(
+        request("/convert?sheet=Q1&sheet=Q2")
+      )
+
+      options.sheetNames shouldBe List("Q1", "Q2")
+    }
+
+    "preserve comma-separated sheet parsing across repeated params" in {
+      val options = RequestHandler.parseConvertOptions(
+        request("/convert?sheet=Q1,Q2&sheet=Q3")
+      )
+
+      options.sheetNames shouldBe List("Q1", "Q2", "Q3")
+    }
+  }


### PR DESCRIPTION
## Summary

Follow-up to #70. Redesigns the aggressive watermark-removal surface: `--aggressive` is now a standalone modifier flag composed with `--remove-watermarks`, instead of the compound `--remove-watermarks-aggressive`.

- **CLI**: `xlcr convert -i in.pdf -o out.pdf --remove-watermarks --aggressive`; `--aggressive` without `--remove-watermarks` is rejected at parse time (Decline validation)
- **HTTP**: `POST /convert?to=pdf&remove-watermarks=true&aggressive=true` replaces `remove-watermarks-aggressive=true`
- **Internal**: `ConvertOptions.removeWatermarksAggressive` renamed to `aggressive`
- No release has shipped the compound flag (#70 is unreleased), so no deprecation shim is needed

## New test coverage

- `CommandsSpec`: watermark flag parsing and the `--aggressive requires --remove-watermarks` validation
- `PdfWatermarkRemovalSpec`: aggressive mode strips trailing vector art that normal mode preserves — aggressive mode previously had no test coverage
- `RequestHandlerSpec` (new file): repeated `sheet` query param collection, watermark param parsing, and defaults

## Test plan

- [x] `./mill __.compile` — all modules
- [x] `./mill core.test.testOnly com.tjclp.xlcr.cli.CommandsSpec` — 41 passed
- [x] `./mill core-aspose.test.testOnly com.tjclp.xlcr.aspose.PdfWatermarkRemovalSpec com.tjclp.xlcr.aspose.AsposeTransformsCapabilitySpec` — 21 passed (local Aspose license)
- [x] `./mill xlcr.test` — all passed
- [x] `./mill __.checkFormat` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)